### PR TITLE
Keep the selection around replace text and set focus to editor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -196,8 +196,9 @@ async function colorize(selections, color, type) {
 
 	await joplin.commands.execute("editor.execCommand", {
 		name: "replaceSelections",
-		args: [colorizedSelections],
+		args: [colorizedSelections, "around"],
 	});
+	await joplin.commands.execute('editor.focus');
 }
 
 async function updateSavedColors(savedColors, changes) {


### PR DESCRIPTION
Hi, great plugin.

There is one problem with the applying process in which is editor lose focus so you cannot quick press Ctrl+Z to redo and the selections are lost as well.
This PR will make sure the selections will remain after pressing Apply and the focus is set to the editor so you can quick redo if neeeded.

Have a great day.
